### PR TITLE
Chrome拡張機能からのアクセスに対応するためAPIを微修正

### DIFF
--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -9,9 +9,9 @@ const openai = new OpenAI({ apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY });
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { url, user_id, parent_folder_id } = body; // フォルダIDを取得
+  const { url, user_id, parent_folder_id = "" } = body; // フォルダIDを取得、デフォルトは空文字
 
-  if (!url || !user_id || !parent_folder_id) {
+  if (!url || !user_id) {
     return NextResponse.json({ error: "Missing required parameters" }, { status: 400 });
   }
 


### PR DESCRIPTION
parent_folder_idのデフォルト値を""に設定。
何もフォルダ指定がない場合はフォルダ外の一番トップに記事が保持される。