### PR TITLE
titleからZennZennを除く処理を追加

### DIFF
--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -23,7 +23,13 @@ export async function POST(req: Request) {
       articleData = await scrapeArticleContent(url);
     }
 
-    const { content, title, tags } = articleData;
+    let { content, title, tags } = articleData;
+
+    // "ZennZenn" をタイトルから除去
+    if (title.endsWith("ZennZenn")) {
+      title = title.replace(/ZennZenn$/, "").trim();
+    }
+
     const summary = await generateSummary(content);
     if (!summary) {
       throw new Error("Failed to generate summary");


### PR DESCRIPTION
Zennの記事の場合、タイトルの後ろに必ず`ZennZenn`が含まれるため、タイトルにそれが含まれる場合は、削除してデータベースに保存する